### PR TITLE
Fix: omniautn_callbak.After login, it create user_experience again

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class Users::OmniauthCallbacksController < ApplicationController
   def omniauth_callback
     @user = User.from_omniauth(request.env["omniauth.auth"].except("extra"))
     if @user.persisted?
-      set_user_total_experience(@user)
+      set_user_total_experience(@user) if @user.new_record?
       sign_in_and_redirect @user
     else
       session["devise.user_attributes"] = @user.attributes


### PR DESCRIPTION
修正
 Omniath_callback

理由
ユーザーの新規作成時のみuser_experienceを作成しなくてはならないが、
ログイン時にもuser_experienceを作成しようとしてエラーが発生するため