### PR TITLE
Add: user can edit and delete only own account

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,21 +3,15 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  before_action :only_private_user, only: [:update, :destroy]
+  before_action :only_login_user!, only: [:edit, :update, :destory]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
-
-  # POST /resource
   def create
     build_resource(sign_up_params)
-
     resource.save
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?
-        flash[:notice] = "Welcome to Japanepa.com!! Enjoy our Service!!!!"
         sign_up(resource_name, resource)
         respond_with resource, location: after_sign_up_path_for(resource)
         set_user_total_experience(resource)
@@ -33,12 +27,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
-
-  # PUT /resource
   def update
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
@@ -55,38 +43,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-
   protected
 
   def after_update_path_for(resource)
@@ -96,14 +52,5 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def update_resource(resource, params)
     resource.update_without_current_password(params)
   end
-
-  #  ログイン後、~~~~~~に移動する
-  # def after_sign_in_path_for(resource)
-  # end
-  # 認証メール送信後、再送ページに遷移する。
-  # def after_inactive_sign_up_path_for(resource)
-  #   new_user_confirmation_path(resource_name)
-  # end
-
 
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,23 +1,4 @@
-# frozen_string_literal: true
-
 class Users::SessionsController < Devise::SessionsController
-  # before_action :reset_session_before_login, only: [ :create ]
-  # skip_before_action :verify_authenticity_token, only: [ :new ]
-
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
 
   private
 
@@ -26,10 +7,5 @@ class Users::SessionsController < Devise::SessionsController
     reset_session
     session[:user_return_to] = user_return_to if user_return_to
   end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,10 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
+  before_action :only_login_user!
 
   def index
     @users = User.includes(:user_experience)
             .order("user_experiences.total_point desc")
+    get_current_level
   end
 
   def show
@@ -13,4 +14,5 @@ class UsersController < ApplicationController
       redirect_to root_path
     end
   end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   require "uri"
+
   def text_url_to_link(text)
     URI.extract(text, ['http', 'https']).uniq.each do |url|
       sub_text = ""
@@ -37,5 +38,9 @@ module ApplicationHelper
     else
       "home_header"
     end
+  end
+
+  def own_profile?(user)
+    current_user.id == user.id
   end
 end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,3 +1,10 @@
 class Level < ApplicationRecord
   validates :threshold, presence: true
+
+  scope :get_current_level, -> {
+    order(threshold: :desc).
+    limit(1).
+    pluck(:id).
+    first
+  }
 end

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,9 +1,11 @@
-<div id="flash">
 <% if flash[:notice] %>
+  <div id="flash">
     <p class="flash_icon"><%= icon("far", "laugh") %></p>
     <p class="flash_message"><%= flash[:notice] %></p>
+  </div>
 <% elsif flash[:alert] %>
+  <div id="flash">
     <p class="flash_icon"><%= icon("far", "dizzy") %></p>
     <p class="flash_message"><%= flash[:alert] %></p>
+  </div>
 <% end %>
-</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <header class="<%= header_color %>">
     <%= render 'layouts/header' %>
     </header>
-    <div id="flash_wrapper"></div>
+    <div id="flash_wrapper"><%= render "layouts/flash" %></div>
     <section id="modalArea" class="modalArea">
       <%= render 'layouts/modal' %>
     </section>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,8 +1,8 @@
 <%= link_to user_path(user), class: "user_wrapper" do %>
-  <div class="user" id="user_<%= user.id %> <%= add_emphasis(user) %>">
-    <p class="rank_number center" id="<%= is_top_3?(user_counter) %>">
-    <%= icon("fas", "crown") if user_counter < 3 %>
-    <%= user_counter + 1 %>
+  <div class="user_ranking_info" id="user_<%= user.id %> <%= add_emphasis(user) %>">
+    <p class="user_rank_number center" id="<%= is_top_3?(user_counter) %>">
+    <span><%= icon("fas", "crown") if user_counter < 3 %></span>
+    <span><%= user_counter + 1 %></span>
     </p>
     <p class="name"><%= user.name %></p>
     <p class="experience"><%= show_total_experience(user) %></p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,14 +1,15 @@
 <% content_for(:html_title) { "Ranking" } %>
 <% breadcrumb :users, @user %>
-<div class="section_wrapper center">
-  <div class="main_section">
-    <h1 class="center ranking_title">Ranking</h1>
+<div class="user_ranking_wrapper center">
+  <h1 class="center ranking_title">Ranking</h1>
+  <div class="your_ranking">
+    <h1>Your Rank is <%= @current_level || "1" %></h1>
+  </div>
     <div class="user_ranking jscroll">
       <% if @users.present? %>
         <%= render partial: 'user', collection: @users, as: :user %>
       <% else %>
         <p class="center">No...user</p>
       <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,10 @@
 <% content_for(:html_title) { "Profile - #{@user.name}" } %>
 <div class="profile_wrapper">
+  <% if own_profile?(@user) %>
   <p class="right edit_profile_btn">
     <%= link_to 'Edit Your Profile', edit_profile_path(@user), id: "edit_profile_btn" %>
   </p>
+  <% end %>
   <div class="user_img_area center">
     <% if @user.img.attached? %>
       <%= image_tag @user.img, id:'present_user_img' %>
@@ -59,6 +61,6 @@
     </li>
   </ul>
     <p class="right">
-      <%= link_to 'delete your account', user_registration_path(@user), method: :delete, id: "delete_account" %>
+      <%= link_to 'delete your account', user_registration_path(@user), method: :delete, id: "delete_account" if own_profile?(@user) %>
     </p>
 </div>


### PR DESCRIPTION
追加
1.他のユーザープロフィールにて編集ボタンが表示されない様にする
2.他のユーザープロフィールへアクセスとするとトップページへ遷移させる
また、フラッシュメッセージも表示させる
3.他のユーザーのプロフィールを編集、削除するリクエストが来たら、トップページへん遷移させる

理由
他のユーザーのプロフィール編集ページへ遷移し、情報の書き換えやアカウントの削除ができてしますため、これを防止する機能を実装しました。
