### PR TITLE
quiz_category/modify_drag_and_drop

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1313,9 +1313,6 @@ QUIZ INDEX
 .narrow_down {
   margin: 60px 0 30px;
 }
-.quizzes_list {
-  margin-top: 30px;
-}
 .question {
   word-break: break-all;
 }
@@ -1551,11 +1548,19 @@ QUIZ CATEGORY
   position: relative;
   margin:10px ;
   text-align: right;
-}
-.category_new span {
-  position: absolute;
-  left: 0;
-  bottom: 0;
+    span {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+  }
+  .category_create_btn, .quiz_create_btn {
+    padding: 5px 10px;
+    color: $white;
+    background-color: $deep_blue;
+  }
+  .category_create_btn:hover, .quiz_create_btn:hover {
+    color: $white;
+  }
 }
 #category_edit_btn {
   font-size: 14px;
@@ -1565,39 +1570,44 @@ QUIZ CATEGORY
 }
 .quiz_category {
   position: relative;
-  font-size: 0;
-  text-align: right;
   border-top: solid 1px #e7e7e7;
   border-bottom: solid 1px #e7e7e7;
+  font-size: 0;
+  text-align: right;
+  .drag_and_drop {
+    position: absolute;
+    top:50%;
+    transform: translateY(-50%);
+    left:10px;
+    width: 75%;
+    text-align: left;
+    font-size: 24px;
+  }
+  .drag_and_drop:hover {
+    cursor: pointer;
+  }
+  a, p {
+    padding: 15px;
+  }
+  .edit_button {
+    font-size: 20px;
+    color: #388abd;
+  }
+  .edit_button:hover {
+    color: $white;
+    background-color: #388abd;
+  }
+  .delete_button {
+    font-size: 20px;
+    color: #F53240;
+  }
+  .delete_button:hover {
+    color: $white;
+    background-color: #F53240;
+  }
 }
 .quiz_category:nth-child(odd), .quiz:nth-child(odd) {
   background-color: #e7e7e7;
-}
-.quiz_category span {
-  position: absolute;
-  top:50%;
-  transform: translateY(-50%);
-  left:10px;
-  font-size: 24px;
-}
-.quiz_category a,.quiz_category p {
-  padding: 15px;
-}
-.quiz_category .edit_button {
-  font-size: 20px;
-  color: #388abd;
-}
-.quiz_category .edit_button:hover {
-  color: $white;
-  background-color: #388abd;
-}
-.quiz_category .delete_button {
-  font-size: 20px;
-  color: #F53240;
-}
-.quiz_category .delete_button:hover {
-  color: $white;
-  background-color: #F53240;
 }
 .quiz_category .chart_button {
   font-size: 20px;

--- a/app/controllers/admin/quiz_categories_controller.rb
+++ b/app/controllers/admin/quiz_categories_controller.rb
@@ -84,10 +84,14 @@ class Admin::QuizCategoriesController < ApplicationController
   end
 
   def sort
-    @category = QuizCategory.find(params[:id])
-    child = @category.categories[params[:from].to_i]
-    child.insert_at(params[:to].to_i + 1)
-    head :ok
+    if params[:id] == "undefined"
+      category = QuizCategory.levels[params[:from].to_i]
+      category.insert_at(params[:to].to_i + 1)
+    else
+      @category = QuizCategory.find(params[:id])
+      child = @category.categories[params[:from].to_i]
+      child.insert_at(params[:to].to_i + 1)
+    end
   end
 
   private

--- a/app/helpers/quiz_categories_helper.rb
+++ b/app/helpers/quiz_categories_helper.rb
@@ -21,4 +21,8 @@ module QuizCategoriesHelper
       "Title 名"
     end
   end
+
+  def title_index?(category)
+    category.present? && category.is_title?
+  end
 end

--- a/app/views/admin/quiz_categories/_category.html.erb
+++ b/app/views/admin/quiz_categories/_category.html.erb
@@ -1,5 +1,5 @@
 <li class="quiz_category" id="category_<%= category.id %>">
-  <span><%= category.name %></span>
+  <span class="drag_and_drop"><%= category.name %></span>
   <%= link_to categories_admin_quiz_category_path(category), class: "edit_button inline" do %>
     <%= icon("fas", "edit") %>詳細
   <% end %>

--- a/app/views/admin/quiz_categories/_category_info.html.erb
+++ b/app/views/admin/quiz_categories/_category_info.html.erb
@@ -7,5 +7,5 @@
   <%= link_to "編集", edit_admin_quiz_category_path(parent), remote: true, id: "category_edit_btn" %>
 </p>
 <% if parent.is_title? %>
-  <p class="center" >経験値 <span id ="quiz_experience"><%= parent.quiz_experience.experience %></span></p>
+  <p class="center" >経験値 <span id ="quiz_experience"><%= parent.quiz_experience.rate %></span></p>
 <% end %>

--- a/app/views/admin/quiz_categories/index.html.erb
+++ b/app/views/admin/quiz_categories/index.html.erb
@@ -9,16 +9,16 @@
   </div>
   <div class="category_children">
     <p class="category_new">
-      <span>※ ドラッグ＆ドロップで並び替え</span>
-      <% if @parent.present? && @parent.is_title? %>
-        <%= link_to 'NEW', new_quiz_admin_quiz_category_path(@parent), class: 'new_button', remote: true %>
+      <span><%= "※ ドラッグ＆ドロップで並び替え" unless title_index?(@parent) %></span>
+      <% if title_index?(@parent) %>
+        <%= link_to 'NEW', new_quiz_admin_quiz_category_path(@parent), class: 'quiz_create_btnn', remote: true %>
       <% elsif @parent.present? %>
-        <%= link_to 'NEW', new_category_admin_quiz_category_path(@parent), class: 'new_button', remote: true %>
+        <%= link_to 'NEW', new_category_admin_quiz_category_path(@parent), class: 'category_create_btn', remote: true %>
       <% else %>
-        <%= link_to 'NEW', new_level_admin_quiz_categories_path, class: 'new_button', remote: true %>
+        <%= link_to 'NEW', new_level_admin_quiz_categories_path, class: 'category_create_btn', remote: true %>
       <% end %>
     </p>
-    <% if @parent.present? && @parent.is_title? %>
+    <% if title_index?(@parent) %>
       <div id="index">
         <table>
           <tbody id ="quizzes_index">


### PR DESCRIPTION
 修正
1.クイズのレベルカテゴリーの並び替えの修正
2.クイズカテゴリーの管理画面のcssを修正(ドラッグアンドドロップ可の表示、新規作成ボタン等)

理由
1.レベルカテゴリーの並び替えだけ機能していなかったため