### PR TITLE
quiz_category/modify_breadcrumb_and_css

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -21,7 +21,7 @@ $yellow: #F8C677;
 $orange: #F39653;
 $white : #fff;
 
-@mixin shadow  {
+@mixin shadow {
   box-shadow: 0 10px 20px -5px rgba(0,0,0,.2);
   -moz-transform: translateY(-2px);
   -webkit-transform: translateY(-2px);
@@ -29,7 +29,7 @@ $white : #fff;
   transition: 0.2s linear;
 }
 
-@mixin center  {
+@mixin center {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -47,16 +47,15 @@ $white : #fff;
 	border-style: initial;
 	-webkit-text-size-adjust: 100%;
 }
-html,body  {
+html,body {
 	height: 100%;
 	width: 100%;
 }
-body  {
+body {
   font-family: 'Hiragino Kaku Gothic ProN','ヒラギノ角ゴ ProN W3','メイリオ', Meiryo,'ヒラギノ角ゴシック','Hiragino Sans',sans-serif;
 	line-height: 2;
-	// letter-spacing: ;s
 }
-a  {
+a {
 	text-decoration: none !important;
 	-webkit-transition: all linear 0.2s;
 	transition: all linear 0.2s;
@@ -64,12 +63,12 @@ a  {
 a:hover {
   opacity: .6;
 }
-img  {
+img {
 	height: auto;
   max-width: 100%;
   object-fit: cover;
 }
-input, button, select, textarea  {
+input, button, select, textarea {
 	-webkit-appearance: none;
 }
 p, h1, h2, h3,h4, ul, li {
@@ -206,7 +205,6 @@ body {
 .breadcrumbs {
   font-size: 20px;
   padding: 10px 0 20px 20px;
-
   a {
     color: gray;
   }
@@ -1537,8 +1535,21 @@ QUIZ CATEGORY
   margin: 50px auto;
   border-radius:5px;
 }
+.breadcrumbs_list {
+  padding: 10px 0 20px 20px;
+  font-size: 20px;
+  li {
+    display: inline-block;
+    a {
+      color: gray;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  }
+}
 .quiz_category_parent {
-  background-color:$white;
+  background-color: $white;
 }
 .parent_name {
   font-size: 36px;
@@ -1934,13 +1945,12 @@ COMMON SEARCH & SORT
 .index_head {
   background-color: #303E58;
   color: #59D3EB;
-  .date_column {
-    width: 15%;
-  }
-  .action_column {
-    width: 12%;
-    font-size: 10px;
-  }
+}
+.date_column {
+  width: 15%;
+}
+.action_column {
+  width: 12%;
 }
 .sort_link {
   display: block;

--- a/app/views/admin/articles/_columns.html.erb
+++ b/app/views/admin/articles/_columns.html.erb
@@ -7,5 +7,5 @@
   <th><%= sort_link(@q, :bookmarks_count, "Bookmarks", default_order: :desc, anchor: "index")%></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可（カラム名をクリック）</th>
 </tr>

--- a/app/views/admin/communities/_column.html.erb
+++ b/app/views/admin/communities/_column.html.erb
@@ -7,5 +7,5 @@
   <th><%= sort_link(@q, :users_name, "Founder", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可（カラム名をクリック）</th>
 </tr>

--- a/app/views/admin/events/_columns.html.erb
+++ b/app/views/admin/events/_columns.html.erb
@@ -7,5 +7,5 @@
   <th class="date_column"><%= sort_link(@q, :end_time, "End Time", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可<br>（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可<br>（カラム名をクリック）</th>
 </tr>

--- a/app/views/admin/information/_columns.html.erb
+++ b/app/views/admin/information/_columns.html.erb
@@ -5,5 +5,5 @@
   <th><%= sort_link(@q, :impressions_count, "Views", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可<br>（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可<br>（カラム名をクリック）</th>
 </tr>

--- a/app/views/admin/quiz_categories/_breadcrumbs.html.erb
+++ b/app/views/admin/quiz_categories/_breadcrumbs.html.erb
@@ -1,0 +1,12 @@
+<ul class="breadcrumbs_list">
+  <li><%= icon("fas","map-marker-alt") %> <%= link_to "Home", root_path %> ＞ <li>
+  <li><%= link_to "クイズカテゴリー TOP", admin_quiz_categories_path %></li>
+  <% if defined?(@parent) %>
+    <% unless @parent.is_level? %>
+      <% @ancestors.each do |ancestor| %>
+        <li>＞ <%= link_to ancestor.name, categories_admin_quiz_category_path(ancestor) %></li>
+      <% end %>
+    <% end %>
+    <li>＞ <%= @parent.name %></li>
+  <% end %>
+</ul>

--- a/app/views/admin/quiz_categories/_breadcrumbs_list.html.erb
+++ b/app/views/admin/quiz_categories/_breadcrumbs_list.html.erb
@@ -1,1 +1,0 @@
-<li class="breadcrumbs">＞ <%= link_to ancestor.name, categories_admin_quiz_category_path(ancestor) %></li>

--- a/app/views/admin/quiz_categories/_category_info.html.erb
+++ b/app/views/admin/quiz_categories/_category_info.html.erb
@@ -1,11 +1,7 @@
-<ul class="breadcrumbs_list">
-  <li><%= link_to "クイズカテゴリー TOP", admin_quiz_categories_path %></li>
-  <%= render partial: 'breadcrumbs_list', collection: ancestors, as: :ancestor %>
-</ul>
 <p class="parent_name center">
   <span id="category_name"><%= parent.name %></span>
   <%= link_to "編集", edit_admin_quiz_category_path(parent), remote: true, id: "category_edit_btn" %>
 </p>
 <% if parent.is_title? %>
-  <p class="center" >経験値 <span id ="quiz_experience"><%= parent.quiz_experience.rate %></span></p>
+  <h2 class="center" >経験値 <span id ="quiz_experience"><%= parent.quiz_experience.rate %></span></h2>
 <% end %>

--- a/app/views/admin/quiz_categories/_create_btn.html.erb
+++ b/app/views/admin/quiz_categories/_create_btn.html.erb
@@ -1,0 +1,10 @@
+<p class="category_new">
+  <span><%= "※ ドラッグ＆ドロップで並び替え" unless title_index?(parent) %></span>
+  <% if title_index?(parent) %>
+    <%= link_to 'NEW', new_quiz_admin_quiz_category_path(parent), class: 'quiz_create_btn', remote: true %>
+  <% elsif @parent.present? %>
+    <%= link_to 'NEW', new_category_admin_quiz_category_path(parent), class: 'category_create_btn', remote: true %>
+  <% else %>
+    <%= link_to 'NEW', new_level_admin_quiz_categories_path, class: 'category_create_btn', remote: true %>
+  <% end %>
+</p>

--- a/app/views/admin/quiz_categories/_quiz.html.erb
+++ b/app/views/admin/quiz_categories/_quiz.html.erb
@@ -1,18 +1,18 @@
 <%= link_to edit_admin_quiz_path(quiz) do %>
   <tr class="index_content" id="quiz_#{quiz_id}">
     <td><%= quiz.id %></td>
-    <td class="truncate_column"><%= get_first_sentence(quiz.question).truncate(20) %></td>
+    <td class="truncate_column"><%= quiz.question.truncate(20) %></td>
     <td><%= quiz.choice1.truncate(20) %></td>
     <td><%= quiz.choice2.truncate(20) %></td>
     <td><%= quiz.choice3.truncate(20) %></td>
     <td><%= quiz.choice4.truncate(20) %></td>
-    <td><%= quiz.updated_at.strftime('%Y/%m/%d') %></td>
-    <td><%= quiz.created_at.strftime('%Y/%m/%d') %></td>
-    <td>
-      <%= link_to edit_quiz_admin_quiz_categories_path(quiz), class: "edit_btn inline" do %>
+    <td class="date_column"><%= quiz.updated_at.strftime('%Y/%m/%d') %></td>
+    <td class="date_column"><%= quiz.created_at.strftime('%Y/%m/%d') %></td>
+    <td class="action_column">
+      <%= link_to edit_admin_quiz_category_path(quiz), class: "edit_btn inline" do %>
         <%= icon("fas", "edit") %> 編集
       <% end %>
-      <%= link_to admin_quiz_path(quiz), class: "delete_btn inline",data: { confirm: 'このユーザーを削除しますか?' } ,method: :delete do %>
+      <%= link_to admin_quiz_path(quiz), class: "delete_btn inline", data: { confirm: 'このユーザーを削除しますか?' } ,method: :delete do %>
         <%= icon("fas", "trash-alt") %> 削除
       <% end %>
     </td>

--- a/app/views/admin/quiz_categories/index.html.erb
+++ b/app/views/admin/quiz_categories/index.html.erb
@@ -1,26 +1,19 @@
 <% content_for(:html_title) { "Quiz Category Index" } %>
+<%= render 'breadcrumbs' %>
 <div class="quiz_categories">
   <div class="quiz_category_parent">
     <% unless @parent %>
-      <p class="parent_name center">Quiz カテゴリー</p>
+      <p class="parent_name center"><%= icon("fas","mp-marker-alt") %> Quiz カテゴリー</p>
     <% else %>
       <%= render partial: 'category_info', locals: { parent: @parent, ancestors: @ancestors } %>
     <% end %>
   </div>
   <div class="category_children">
-    <p class="category_new">
-      <span><%= "※ ドラッグ＆ドロップで並び替え" unless title_index?(@parent) %></span>
-      <% if title_index?(@parent) %>
-        <%= link_to 'NEW', new_quiz_admin_quiz_category_path(@parent), class: 'quiz_create_btnn', remote: true %>
-      <% elsif @parent.present? %>
-        <%= link_to 'NEW', new_category_admin_quiz_category_path(@parent), class: 'category_create_btn', remote: true %>
-      <% else %>
-        <%= link_to 'NEW', new_level_admin_quiz_categories_path, class: 'category_create_btn', remote: true %>
-      <% end %>
-    </p>
+    <%= render 'create_btn', parent: @parent %>
     <% if title_index?(@parent) %>
-      <div id="index">
+      <div id="category index">
         <table>
+          <%= render 'quiz_columns' %>
           <tbody id ="quizzes_index">
             <%= render partial: 'admin/quizzes/quiz', collection: @quizzes, as: :quiz %>
           </tbody>

--- a/app/views/admin/quizzes/_columns.html.erb
+++ b/app/views/admin/quizzes/_columns.html.erb
@@ -7,5 +7,5 @@
   <th><%= sort_link(@q, :choice4, "C4", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可<br>（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可<br>（カラム名をクリック）</th>
 </tr>

--- a/app/views/admin/quizzes/_quiz.html.erb
+++ b/app/views/admin/quizzes/_quiz.html.erb
@@ -5,9 +5,9 @@
   <td><%= quiz.choice2.truncate(20) %></td>
   <td><%= quiz.choice3.truncate(20) %></td>
   <td><%= quiz.choice4.truncate(20) %></td>
-  <td><%= quiz.updated_at.strftime('%Y/%m/%d') %></td>
-  <td><%= quiz.created_at.strftime('%Y/%m/%d') %></td>
-  <td>
+  <td class="date_column"><%= quiz.updated_at.strftime('%Y/%m/%d') %></td>
+  <td class="date_column"><%= quiz.created_at.strftime('%Y/%m/%d') %></td>
+  <td class="action_column">
     <%= link_to edit_admin_quiz_path(quiz), class: "edit_btn inline" do %>
       <%= icon("fas", "edit") %> 編集
     <% end %>

--- a/app/views/admin/talks/_columns.html.erb
+++ b/app/views/admin/talks/_columns.html.erb
@@ -6,5 +6,5 @@
   <th><%= sort_link(@q, :likes_count, "Likes", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可<br>（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可<br>（カラム名をクリック）</th>
 </tr>

--- a/app/views/admin/users/_columns.html.erb
+++ b/app/views/admin/users/_columns.html.erb
@@ -7,5 +7,5 @@
   <th><%= sort_link(@q, :country, "Country", default_order: :desc, anchor: "index")%></th>
   <th><%= sort_link(@q, :current_address, "Address", default_order: :desc, anchor: "index")%></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
-  <th class="action_column">※ソート可<br>（カラム名をクリック）</th>
+  <th class="action_column notes">※ソート可<br>（カラム名をクリック）</th>
 </tr>


### PR DESCRIPTION
修正
1.クイズカテゴリー画面のパンくずを修正し、パーシャル化
2.パンくずのcssを修正

理由
1.パンくずの位置が他の管理画面ページと異なってたため
2.クイズカテゴリーのパンくずはgemを使っておらず、他のパンくずとデザインが異なっていたため

ーーーーーーーー
追加
1.クイズカテゴリーのクイズ一覧にカラムを追加

理由
1.カラムがないためにテーブルのデータが何の情報であるか不明瞭であったため