### PR TITLE
quiz_category_form/modify_category_with_experience_form

### DIFF
--- a/app/controllers/admin/quiz_categories_controller.rb
+++ b/app/controllers/admin/quiz_categories_controller.rb
@@ -69,20 +69,6 @@ class Admin::QuizCategoriesController < ApplicationController
     @category = QuizCategory.find(params[:id]).destroy
   end
 
-  def search
-    is_pagination?(params)
-    if params[:q]['name_or_introduction_or_users_name_cont_any'] != nil
-      params[:q]['name_or_introduction_or_users_name_cont_any'] = params[:q]['name_or_introduction_or_users_name_cont_any'].split(/[ ]/)
-      @keywords = Community.ransack(params[:q])
-      @communities = @keywords.result.sorted.page(params[:page])
-      @q = Community.ransack(params[:q])
-    else
-      @q = Community.ransack(params[:q])
-      @communities = @q.result(distinct: true).sorted.page(params[:page])
-    end
-    render template: 'admin/communities/index'
-  end
-
   def sort
     if params[:id] == "undefined"
       category = QuizCategory.levels[params[:from].to_i]
@@ -97,11 +83,11 @@ class Admin::QuizCategoriesController < ApplicationController
   private
 
   def category_params
-    params.require(:quiz_category).permit(:name, :parent_id, :experience, :id)
+    params.require(:quiz_category).permit(:name, :parent_id, :rate, :id)
   end
 
   def category_with_experience_params
-    params.require(:category_with_experience_form).permit(:name, :parent_id, :experience)
+    params.require(:category_with_experience_form).permit(:name, :parent_id, :rate)
   end
 
   def get_children_category(category)

--- a/app/forms/category_with_experience_form.rb
+++ b/app/forms/category_with_experience_form.rb
@@ -1,16 +1,16 @@
 class CategoryWithExperienceForm
   include ActiveModel::Model
 
-  attr_accessor :name, :parent_id, :experience, :id
+  attr_accessor :name, :parent_id, :rate, :id
 
-  validates :name, :parent_id, :experience, presence: true
+  validates :name, :parent_id, :rate, presence: true
 
   def save
     return false if invalid?
     @category = QuizCategory.new(name: name, parent_id: parent_id)
     @category.save
     @experience = experience
-    quiz_experience = QuizExperience.new(title_id: @category.id, experience: @experience)
+    quiz_experience = QuizExperience.new(title_id: @category.id, rate: @experience)
     quiz_experience.save
   end
 
@@ -19,7 +19,7 @@ class CategoryWithExperienceForm
     @category.update(name: name)
     @category.save
     @quiz_experience = QuizExperience.find_by(title_id: @category.id)
-    @quiz_experience.update(experience: experience)
+    @quiz_experience.update(rate: rate)
     @quiz_experience.save
   end
 end

--- a/app/models/quiz_experience.rb
+++ b/app/models/quiz_experience.rb
@@ -1,5 +1,5 @@
 class QuizExperience < ApplicationRecord
   belongs_to :category, foreign_key: 'title_id', class_name: 'QuizCategory'
-  validates :title_id, :experience, presence: true
+  validates :title_id, :rate, presence: true
   validates :title_id, uniqueness: true
 end

--- a/app/views/admin/quiz_categories/_edit_form.html.erb
+++ b/app/views/admin/quiz_categories/_edit_form.html.erb
@@ -9,7 +9,7 @@
     <% if category.is_title? %>
       <div class="field" >
         <p class="bold">経験値</p>
-        <%= f.select :experience, experience_array, id: 'form_input', selected: category.quiz_experience.experience %>
+        <%= f.select :rate, experience_array, id: 'form_input', selected: category.quiz_experience.rate %>
       </div>
     <% end %>
     <div class="form_btn">

--- a/app/views/admin/quiz_categories/_form.html.erb
+++ b/app/views/admin/quiz_categories/_form.html.erb
@@ -9,7 +9,7 @@
       <% if defined?(parent) && parent.is_section? %>
         <div class="field" >
           <p class="bold">経験値</p>
-          <%= f.select :experience, experience_array, id: 'form_input' %>
+          <%= f.select :rate, experience_array, id: 'form_input' %>
         </div>
       <% end %>
     <div class="form_btn">

--- a/app/views/admin/quiz_categories/update.js.erb
+++ b/app/views/admin/quiz_categories/update.js.erb
@@ -1,5 +1,5 @@
 $('#category_name').text("<%= @category.name %>");
-<% if defined?(@category.experience) %>
-  $('#quiz_experience').text("<%= @category.experience %>");
- <% end %> 
+<% if defined?(@category.rate) %>
+  $('#quiz_experience').text("<%= @category.rate %>");
+<% end %> 
 $('#modalArea').fadeOut();


### PR DESCRIPTION
修正
1.クイズカテゴリーフォームを一部修正
2.ajaxで変更された経験値を表示させる

理由
1.経験値テーブルのカラムを「experience」から「rate」 に変更ため
2.同上