### PR TITLE
upload_img_form/modify_upload_img_form_and_apply changes to all form

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -182,23 +182,6 @@ $('.accordion p').on('click',function(){
       });
     }
   });
-  // 画像アップロード プレ画像
-  function readURL(input) {
-    if (input.files && input.files[0]) {
-      var reader = new FileReader();
-      reader.onload = function (e) {
-        $('#new_img, #new_user_img').attr('src', e.target.result);
-      }
-      reader.readAsDataURL(input.files[0]);
-    }
-  };
-  $(function () {
-    $('#input_img').on('change', function () {
-      $('#new_img, #new_user_img').removeClass('hidden');
-      $('#present_img, #present_user_img, #no_img, #no_user_img').remove();
-      readURL(this);
-    });
-  });
   // カレンダー入力共通設定
   $('#creation_date_from, #update_date_from, #start_time_from, #end_time_from, #start_time').datetimepicker({
     format: 'L',

--- a/app/assets/javascripts/prev_img.js
+++ b/app/assets/javascripts/prev_img.js
@@ -1,16 +1,25 @@
+// 画像アップロード プレ画像
 function readURL(input) {
   if (input.files && input.files[0]) {
     var reader = new FileReader();
     reader.onload = function (e) {
-      $('#prev_img').attr('src', e.target.result);
+      $('#new_img, #new_user_img').attr('src', e.target.result);
     }
     reader.readAsDataURL(input.files[0]);
   }
 };
-
-$('#post_img').on('change', function () {
-  $('#prev_img').removeClass('hidden');
-  $('.present_img').remove();
-  readURL(this);
-  $('#cancel_img').removeClass('hidden');
+$(function () {
+  $('#input_img').on('change', function () {
+    $('#new_img, #new_user_img').removeClass('hidden');
+    $('#present_img, #present_user_img, #no_img, #no_user_img').remove();
+    readURL(this);
+    $('#cancel_img_btn, #delete_img_btn, #new_img, #present_img, #new_user_img').removeClass('hidden');
+    $('input[type="checkbox"]').removeAttr('checked').prop('checked', false).change();
+  });
+  $('#cancel_img_btn, #delete_img_btn').on('click', function () {
+    $('#input_img').val("");
+    $('#new_img, #new_user_img, #present_img').attr('src', "");
+    $('#cancel_img_btn, #delete_img_btn, #new_img, #present_img, #new_user_img').addClass('hidden');
+    $('input[type="checkbox"]').attr('checked', true).prop('checked', true).change();
+  })
 });

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1005,30 +1005,26 @@ input[type="submit"], .upload_btn {
 label input {
   display: none;
 }
-.inline_radio  {
+.inline_radio {
   display: flex;
   margin-bottom: 30px;
   border-radius: 3px;
   overflow: hidden;
   border: 1px solid #b6b6b6;
-
   div {
     position: relative;
     flex: 1;
     font-size: 40px;
   }
-
   div:hover {
     cursor: pointer;
   }
-
   input  {
     width: 100%;
     height: 100%;
     opacity: 0;
   }
-
-  label  {
+  label {
     position: absolute;
     top: 0; left: 0;
     color: #b6b6b6;
@@ -1041,21 +1037,24 @@ label input {
     pointer-events: none;
     border-right: 1px solid #b6b6b6;
   }
-
   div:last-child label {
     border-right: 0;
   }
-
   input:checked + label {
     background: $red;
     font-weight: 500;
     color: $white;
   }
-
   input:hover {
     cursor: pointer;
   }
-
+}
+#cancel_img_btn, #delete_img_btn {
+  margin-left: 20px;
+}
+#cancel_img_btn:hover, #delete_img_btn:hover {
+  color: $red;
+  cursor: pointer;
 }
 /*---------------
 USER_FORM ADMIN_FORM

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -37,6 +37,7 @@ class Admin::ArticlesController < ApplicationController
     @article = Article.find(params[:id])
     @article.update(article_params)
     if @article.save
+      @article.img.purge if article_params[:delete_img].present?
       flash.now[:notice] = 'article was updated successfully'
       redirect_to admin_articles_path
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    added_attrs = [:name, :country, :current_address, :password, :password_confirmation, :img]
+    added_attrs = [:name, :country, :current_address, :password, :password_confirmation, :img, :delete_img]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
     devise_parameter_sanitizer.permit(:sign_in) { |u| u.permit(:name, :password) }

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -47,7 +47,7 @@ class CommunitiesController < ApplicationController
   def update
     @community = Community.find(params[:id])
     if @community.update(community_params) && current_user.is_founder?(@community)
-      flash.now[:notice] = "community was updated"
+      @community.img.purge if params[:community][:delete_img]
       redirect_to community_path(@community)
     else
       render 'edit'

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -44,7 +44,7 @@ class TalksController < ApplicationController
   def update
     @talk = Talk.find(params[:id])
     if @talk.update(talk_params)
-      flash.now[:notice] = "talk was updated"
+      @talk.img.purge if params[:talk][:delete_img].present?
     else
       flash.now[:alert] = "failed to update.... try again"
       render :edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
-  before_action :only_private_user, only: [:update, :destroy]
   before_action :only_login_user!, only: [:edit, :update, :destory]
 
   def create
@@ -33,6 +32,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     resource_updated = update_resource(resource, account_update_params)
     yield resource if block_given?
     if resource_updated
+      resource.img.purge if params[:user][:delete_img].present?
       set_flash_message_for_update(resource, prev_unconfirmed_email)
       bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
       redirect_to user_path(resource)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :like_talks, dependent: :destroy
   has_many :talks, through: :like_talks
+  has_many :talks, dependent: :destroy
   has_many :like_articles, dependent: :destroy
   has_many :articles, through: :like_articles
   has_many :bookmarks, dependent: :destroy

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -14,22 +14,7 @@
     <p class="bold">Tags</p>
     <ul id="form-tags" class="tag_input"></ul>
   </div>
-  <div class="field">
-    <p class="bold">Top-Image</p>
-    <div class="post_img_area">
-      <% if @article.img.attached? %>
-        <%= image_tag @article.img, id: 'present_img' %>
-      <% else %>
-        <img id="no_img" src="https://kukuhana.s3-ap-northeast-1.amazonaws.com/no_img.jpg" />
-        <%= f.hidden_field :img_cache %>
-      <% end %>
-      <img id="new_img" src="#" class='hidden' />
-      <label for="input_img" class="input_img">
-        <p class="center upload_btn">Upload</p>
-        <%= f.file_field :img, id: 'input_img' %>
-      </label>
-    </div>
-  </div>
+  <%= render 'upload_img', model: @article, f: f %>
   <div class="field">
     <%= f.label :contents %>
     <%= f.text_area :contents, 'data-provider': :summernote %>

--- a/app/views/application/_upload_img.html.erb
+++ b/app/views/application/_upload_img.html.erb
@@ -1,19 +1,17 @@
 <div class="field post_img_area">
   <p>Image</p>
-  <div>
-    <%= image_tag model.img, id: 'present_img' if model.img.attached? %>
-    <img id="new_img" src="#" class='hidden' />
-  </div>
+  <%= image_tag model.img, id: 'present_img' if model.img.attached? %>
+  <img id="new_img" src="#" class='hidden' />
   <label for="input_img" class="input_img inline">
     <p class="center upload_btn inline">Upload</p>
     <%= f.file_field :img, id: 'input_img', class: "hidden" %>
   </label>
   <div id="delete_img_wrapper" class="field inline">
     <% if model.img.attached? %>
-        <%= f.label :delete_img, for:"delete_img", id: "delete_img_btn" %>
-        <%= f.check_box :delete_img, {}, true, nil %>
+        <%= f.label :delete_img, for: "delete_img", id: "delete_img_btn" %>
+        <p class="hidden"><%= icon("fas","trash") %> <%= f.check_box :delete_img, {}, true, nil %></p>
     <% else %>
-      <p id="clear_img" class="hidden bold">Cancel Image</p>
+      <p id="cancel_img_btn" class="hidden bold"><%= icon("fas","trash") %> Cancel Image</p>
     <% end %>
   </div>
 </div>

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -9,22 +9,8 @@
     <p>Tag</p>
     <ul id="form_tags" class="tag_input"></ul>
   </div>
-  <div class="field">
-    <p class="bold">Image</p>
-    <label for="input_img" class="input_img">
-      <p class="center upload_btn">Upload</p>
-      <%= f.file_field :img, id: 'input_img' %>
-    </label>
-    <div class="post_img_area">
-      <% if @community.img.attached? %>
-        <%= image_tag @community.img, id: 'present_img' %>
-      <% else %>
-        <img id="no_img" src="https://kukuhana.s3-ap-northeast-1.amazonaws.com/no_img.jpg" />
-      <% end %>
-      <img id="new_img" src="#" class='hidden' />
-    </div>
-  </div>
-  <div class="field bold"> 
+  <%= render 'upload_img', model: @community, f: f %>
+  <div class="field bold">
     <%= f.label :introduction %><br>
     <%= f.text_area :introduction %>
   </div>

--- a/app/views/communities/_side_section.html.erb
+++ b/app/views/communities/_side_section.html.erb
@@ -2,14 +2,11 @@
   <div>
     <h4><%= icon("fas", "tags") %> Menu (メニュー)</h4>
     <div class="side_inner_box">
-      <p>Hi there! Come here to check in with your favorite communities
-        and learn japanese with our Members!</p>
-      <% if past_30days_after_signIn? %>
-        <%= link_to 'create community', new_community_path, class: 'block center create_btn' %>
-      <% else %>
-        <p>can't create communities yet</p>
-        <p>To prevent spam,account must be at least 30 days old</p>
-      <% end %>
+      <p>
+        Hi there! Come here to check in with your favorite communities
+        and learn japanese with our Members!
+      </p>
+      <%= link_to 'create community', new_community_path, class: 'block center create_btn' %>
     </div>
   </div>
 </div>

--- a/app/views/talks/_form.html.erb
+++ b/app/views/talks/_form.html.erb
@@ -2,21 +2,11 @@
   <div class="field select_communities">
 <%= render partial: 'community_id',locals: { community: @community, communities: @communities, f: f } %>
   </div>
-  <div class="field">
-    <p class="bold">Image</p>
-    <div class="post_img_area">
-      <%= image_tag talk.img, id: 'present_img' if talk.img.attached? %>
-      <img id="new_img" src="#" class='hidden' />
-      <label for="input_img" class="input_img">
-        <p class="center upload_btn">Upload</p>
-        <%= f.file_field :img, id: 'input_img' %>
-      </label>
-    </div>
-  </div>
-  <div class="field input_content"> 
+  <div class="field input_content">
     <%= f.label :content %><br>
     <%= f.text_area :content %>
   </div>
+  <%= render 'upload_img', model: talk, f: f %>
   <div class="actions">
     <%= f.submit "Post" %>
   </div>


### PR DESCRIPTION
修正
1.画像アップロードのキャンセルボタンと登録済画像の削除ボタンを修正
2.上記のボタンを全てのフォームに適応させる

背景
1.新規にアップロードしようとした画像のキャンセルボタンがなかったので、アップロードの取り消しができない。
画像削除にチェックボックスを使うと画像が削除されることがわかりにくい。
したがって、ボタンを押すとアップロードのプレビュー画像や登録画像がフォームから消える使用にするとUXが上がると考えた