### PR TITLE
管理画面のtalk一覧画面にコメント数のカラムを追加

### DIFF
--- a/app/views/admin/talks/_columns.html.erb
+++ b/app/views/admin/talks/_columns.html.erb
@@ -4,6 +4,7 @@
   <th><%= sort_link(@q, :users_name, "User", default_order: :desc, anchor: "index") %></th>
   <th><%= sort_link(@q, :content, "content", default_order: :desc, anchor: "index") %></th>
   <th><%= sort_link(@q, :likes_count, "Likes", default_order: :desc, anchor: "index") %></th>
+  <th><%= sort_link(@q, :comments_count, "Comments", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :created_at, "Creation Data", default_order: :desc, anchor: "index") %></th>
   <th class="date_column"><%= sort_link(@q, :updated_at, "Update Date", default_order: :desc, anchor: "index") %></th>
   <th class="action_column notes">※ソート可<br>（カラム名をクリック）</th>

--- a/app/views/admin/talks/_talk.html.erb
+++ b/app/views/admin/talks/_talk.html.erb
@@ -4,6 +4,7 @@
   <td><%= talk.user.name %></td>
   <td><%= talk.content.truncate(20) %></td>
   <td><%= number_with_delimiter(talk.likes_count) %></td>
+  <td><%= number_with_delimiter(talk.comments_count) %></td>
   <td><%= talk.created_at.strftime('%Y/%m/%d') %></td>
   <td><%= talk.updated_at.strftime('%Y/%m/%d') %></td>
   <td>


### PR DESCRIPTION
・Issue
[#42 ](https://github.com/hidetoshi-tsubaki/japanepa.com/issues/42)

・内容
管理画面のtalk一覧画面にコメント数のカラムを追加しました。
「comments」のカラムをクリックするとコメント数による昇順・降順の並び替えができる

