### PR TITLE
ユーザー用画面のコメント一覧を開閉できる機能を追加

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -15,6 +15,10 @@ $(function () {
     $('#modalArea').fadeIn();
     $('#LoginModal').removeClass('hidden');
   });
+  // コメント一覧の開閉
+  $('.comment_btn').on('click', function () {
+    $(this).parent().next().fadeToggle();
+  })
   // トップへ戻る
   $(function () {
     var pageTop1 = $("#to_top_btn");

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -294,12 +294,11 @@ body {
     bottom: -55px;
     right: 0;
     width: 90px;
-    padding: 5px;
     background-color: $white;
-    li:first-child {
-      margin-bottom: 10px;
+    li {
       a {
-        width: 100%;
+        display: block;
+        text-align: start;
       }
     }
   }
@@ -460,7 +459,7 @@ footer p {
 /*---------------
 2.3 MODAL
 ----------------*/ 
-.modalArea  {
+.modalArea {
   display: none;
   position: fixed;
   z-index: 10;
@@ -469,7 +468,7 @@ footer p {
   width: 100%;
   height: 100%;
 }
-.modalBg  {
+.modalBg {
   width: 100%;
   height: 100%;
   background-color: rgba(30,30,30,0.3);
@@ -479,9 +478,8 @@ footer p {
   top: 50%;
   left: 50%;
   transform:translate(-50%,-50%);
-  width: 70%;
-  height:70%;
-  padding: 10px 30px;
+  width: 85%;
+  padding: 60px 30px;
   background-color: $white;
 }
 #modal {
@@ -1015,6 +1013,8 @@ input[type="submit"], .upload_btn {
   textarea {
     background-color: $white;
   }
+}
+.comment_form {
   input[type="submit"] {
   margin: 5px 0 0 auto;
   }
@@ -1222,8 +1222,13 @@ TALKS
 .comment_btn a, .like_btn a {
   text-decoration: none;
 }
-.comment_btn a {
+.comment_btn
+  a {
   color: $blue;
+}
+.comment_btn:hover {
+  cursor: pointer;
+  opacity: .7;
 }
 .warn_sentence {
   border: 2px solid gray;

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -1,4 +1,5 @@
 <div class="talk_wrapper" id="talk_<%= talk.id%>">
+  <%= render 'talks/action_btns', talk: talk, community: @community %>
   <%= render 'talks/info_of_poster', talk: talk %>
   <div class="talk_content_wrapper">
     <%= simple_format(text_url_to_link(h(talk.content)).html_safe, class: 'talk_content') %>
@@ -16,7 +17,6 @@
         <%= render partial:'talks/like_btn' ,locals: { talk: talk } %>
     </li>
   </ul>
-  <%= render 'talks/action_btns', talk: talk, community: @community %>
   <div id="comments_wrapper_<%= talk.id%>" class="hidden comments_wrapper">
     <%= render 'comments/form', comment: @comment, talk: talk %>
     <div id="comments_of_talk<%= talk.id %>">


### PR DESCRIPTION
・ISSUE
[#38 ](https://github.com/hidetoshi-tsubaki/japanepa.com/issues/38)

・内容
ユーザー用画面にて、表示したコメント一覧を非表示にできる機能を追加しました。
一度開いたコメントを閉じることができず、前後の投稿を再度閲覧する際に邪魔になることがあるので、開いたコメントを再度非表示にできるように修正しました。
