### PR TITLE
feature/#59/202005/modify quiz title design

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1638,7 +1638,9 @@ QUIZ CATEGORY
   position: relative;
   border-top: solid 1px #e7e7e7;
   border-bottom: solid 1px #e7e7e7;
-  text-align: right;
+  .title_name {
+    width: 50%;
+  }
   .graph {
     position: relative;
     width: 300px;

--- a/app/views/quizzes/_title.html.erb
+++ b/app/views/quizzes/_title.html.erb
@@ -4,7 +4,7 @@
       <%= get_learning_level(current_user, title) %>
     </span>
 　　</div>
-  <span><%= title.name %></span>
+  <span class="title_name bold center inline"><%= title.name %></span>
   <%= link_to play_quiz_path(title), class: "edit_button inline" do %>
     <%= icon("far", "play-circle") %>Play
   <% end %>


### PR DESCRIPTION
ISSUE
[#57 ](https://github.com/hidetoshi-tsubaki/japanepa.com/issues/57)

内容
ユーザー用クイズ一覧ページにて、クイズタイトルの位置とフォントサイズを変更