### PR TITLE
feature/#53/202005/add access limit to admin use page

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,5 +1,6 @@
 
 class Admin::AnnouncementsController < ApplicationController
+  before_action :authenticate_admin!
 
   def index
     @q = Announcement.ransack(params[:q])

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,4 +1,5 @@
 class Admin::EventsController < ApplicationController
+  before_action :authenticate_admin!
   before_action :from_calendar?, except: [:index, :calendar, :search]
 
   def index

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,6 +1,5 @@
-# frozen_string_literal: true
-
 class Admin::SessionsController < Devise::SessionsController
+  before_action :authenticate_admin!, only: :destroy
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in


### PR DESCRIPTION
ISSUE
[#59 ](https://github.com/hidetoshi-tsubaki/japanepa.com/issues/59)

内容
管理者用のお知らせ・イベントコントローラーに「before_action: :authenticate_admin!」を追記