### PR TITLE
追加: ユーザー数、記事閲覧回数、クイズのプレイ数などの集計結果グラフを表示する

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,7 @@
 //= require jquery.jscroll.min
 //= require infinite_scroll
 //= require Sortable.min
+//= require counting_chart
 
 //= require tempusdominus-bootstrap-4.js
 // require_tree .

--- a/app/assets/javascripts/counting_chart.js
+++ b/app/assets/javascripts/counting_chart.js
@@ -2,9 +2,8 @@ $(function () {
   function showCountingChart(data, chartID, max_count, color) {
     // 最新の数値を表示
     var last_data = data[data.length-1];
-    var show_last_data_target = ".last_" + chartID + "_count"
+    var show_last_data_target = "#current_" + chartID + "_count"
     $(show_last_data_target).text(last_data);
-    // chartに表示する空のラベルを生成
     var scoreLabels = Array(data.length);
     scoreLabels.fill("");
     var labelArray = scoreLabels;
@@ -13,7 +12,6 @@ $(function () {
     if (myChart) {
       myChart.destroy();
     }
-
     var myChart = new Chart(ctx, {
       data: {
         labels: labelArray,

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -383,7 +383,7 @@ header > div {
   width: 40px;
 }
 .fa-user-cog {
-  font-size: 48px;
+  font-size: 26px;
   color: #767676;
 }
 #header_user_img {
@@ -560,7 +560,7 @@ button  {
   font-size: 10px;
 }
 /*---------------
-Home FOR MEMBER
+Home Common
 ---------------*/
 .upper_block, .admin_upper_block {
   height: calc( calc(100vh - 60px) * 0.6666 );
@@ -595,7 +595,6 @@ Home FOR MEMBER
 	transition: all linear 0.4s;
   z-index: -1;
 }
-
 .menu_panel:hover:after {
   height: 240%;
   opacity: 1;
@@ -676,6 +675,39 @@ Home FOR MEMBER
 }
 .event_panel:hover {
   color: #B8845D;
+}
+/*---------------
+HOME FOR ADMIN USER
+---------------*/
+.counting_chart_wrapper {
+  position: relative;
+  height: 60%;
+  width: 100%;
+  margin-bottom: 15px;
+  padding-right: 15px;
+  background: $white;
+}
+.current_count {
+  position: absolute;
+  bottom: 15%;
+  right: 2%;
+  font-size: 48px;
+  opacity: .7;
+}
+#current_users_count {
+  color: $orange;
+}
+#current_quiz_play_count {
+  color: $pink;
+}
+#current_article_views_count {
+  color: $blue;
+}
+#current_communities_count {
+  color: $yellow;
+}
+#current_talks_count {
+  color: $green;
 }
 /*---------------
 EVENT

--- a/app/controllers/admin/static_pages_controller.rb
+++ b/app/controllers/admin/static_pages_controller.rb
@@ -2,7 +2,11 @@ class Admin::StaticPagesController < ApplicationController
     before_action :authenticate_admin!
 
   def home
-    @events = Event.where(status: true)
-    @anouncement = Announcement.where(status: true)
+    @countings = %w(users quiz_play article_views communities talks)
+    gon.users_counting = Counting.pluck(:users)
+    gon.quiz_play_counting = Counting.pluck(:quiz_play)
+    gon.article_views_counting = Counting.pluck(:article_views)
+    gon.communities_counting = Counting.pluck(:communities)
+    gon.talks_counting = Counting.pluck(:talks)
   end
 end

--- a/app/views/admin/static_pages/_service_status_panel.html.erb
+++ b/app/views/admin/static_pages/_service_status_panel.html.erb
@@ -1,8 +1,6 @@
-<%= month_calendar events: @events do |date, events| %>
-  <%= date.day %>
-  <% events.each do |event| %>
-    <p class="event <%= event_color(event.id) %>" id="<%= event.id %>">
-      <%= event.name %>
-    </p>
-  <% end %>
+<% @countings.each do |counting| %>
+  <div class="counting_chart_wrapper">
+    <canvas id="<%= counting %>"></canvas>
+    <p id="current_<%= counting %>_count" class="current_count bold"></p>
+  </div>
 <% end %>

--- a/app/views/admin/static_pages/home.html.erb
+++ b/app/views/admin/static_pages/home.html.erb
@@ -42,3 +42,4 @@
     </div>
   <% end %>
 </div>
+<%= javascript_include_tag 'counting_chart.js' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -24,6 +24,7 @@ Rails.application.config.assets.precompile += %w( summernote-bs4.min.js )
 Rails.application.config.assets.precompile += %w( summernote.js )
 Rails.application.config.assets.precompile += %w( community.js )
 Rails.application.config.assets.precompile += %w( score_record.js )
+Rails.application.config.assets.precompile += %w( counting_chart.js )
 
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,25 +1,13 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
-
 require File.expand_path(File.dirname(__FILE__) + '/environment')
 rails_env = ENV['RAILS_ENV'] || :development
-# cronを実行する環境変数をセット
 set :environment, rails_env
-# cronのログの吐き出し場所
 set :output, "#{Rails.root}/log/cron.log"
+
+# every 1.day, :at => '0am' do
+#   rake 'counting:counting_date'
+# end
 
 every 1.day, :at => '0am' do
   rake 'counting:counting_date'
 end
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
+

--- a/lib/tasks/counting.rake
+++ b/lib/tasks/counting.rake
@@ -16,15 +16,19 @@ namespace :counting do
       communities: community_count,
       talks: talk_count
     )
+    time = Time.now
     if counting.save
-      number = Counting.count
-      p "it was successed to Batch prosessing(batch No.#{number})"
+      p "successed to Batch prosessing(#{time})"
     else
-      number = Countig.count
-      p "failed Batch prosessing failed（batch No.#{number+1}"
+      p "***********************************************************"
+      p "  failed Batch prosessing failed（#{time}) "
+      p "***********************************************************"
+      p ""
+      p "----------error messages------------"
       counting.errors.full_messages.each_with_index do |message, index|
         p "#{index}: #{message}"
       end
+      p "------------------------------------"
     end
   end
 end


### PR DESCRIPTION
ISSUE
[#36  ](https://github.com/hidetoshi-tsubaki/japanepa.com/issues/36)

内容
・管理画面のトップページにて、下記の日毎の推移をグラフで表示させる
「ユーザー数、クイズのプレイ回数、記事閲覧数、コミュニティー数、投稿数」
・毎日０時に集計バッチを回す
