### PR TITLE
ユーザーモデルに「レベル」カラムを追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -3316,13 +3316,18 @@ ADMIN COMMON INDEX
   .user_search, .talk_search, .event_search {
     margin: 15px 0;
   }
-  .index_table {
-    font-size: 14px;
-    thead th:not(:last-child) {
-      padding: 0 8px;
-    }
-    thead, tbody {
-      min-width: 531px;
+  .table_wrapper {
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    .index_table {
+      font-size: 14px;
+      thead th:not(:last-child) {
+        padding: 0 8px;
+      }
+      thead, tbody {
+        min-width: 850px;
+      }
     }
   }
   .no_data {
@@ -3338,8 +3343,8 @@ ADMIN COMMON INDEX
     }
   }
   .table_wrapper {
-    overflow-x: scroll;
-    white-space: nowrap;
-    -webkit-overflow-scrolling: touch;
+    .index_table thead, tbody {
+      min-width: 531px;
+    }
   }
 }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -8,7 +8,7 @@ class Admin::UsersController < ApplicationController
   
   def show
     @user = User.find(params[:id])
-    get_user_level(@user)
+    get_needed_level(@user)
   end
 
   def destroy

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,6 +1,6 @@
 class AnnouncementsController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level, only: :index
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, only: :index
   impressionist :actions => [:show]
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,20 +15,10 @@ class ApplicationController < ActionController::Base
     root_path
   end
 
-  def get_current_level
-    return unless user_signed_in?
-    user_experience = current_user.user_experience
-    @current_experience = user_experience.total_point
-    @current_level = Level.where("threshold <= ?", @current_experience).order(threshold: :desc).limit(1).pluck(:id).first
+  def get_needed_experience(user)
+    @needed_experience_to_next_level = Level.find(user.level).threshold - user.user_experience.total_point
   end
 
-  def get_user_level(user)
-    user_experience = user.user_experience
-    @current_experience = user_experience.total_point
-    @current_level = Level.where("threshold <= ?", @current_experience).order(threshold: :desc).limit(1).pluck(:id).first
-    next_level = Level.where("threshold > ?", @current_experience).first
-    @needed_experience_to_next_level = next_level.threshold - @current_experience
-  end
 
   def get_unchecked_announce_count
     return unless user_signed_in?

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_current_level, :get_not_done_reviews_count
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
   before_action :set_article_tags, only: [:index, :search, :tag_search]
   before_action :set_ranked_articles, only: [:show, :index, :search, :tag_search]
   impressionist :actions => [:show]

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,6 @@
 class BookmarksController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_current_level, :get_not_done_reviews_count, only: :index
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, only: :index
 
   def index
     @articles = Article.bookmarks

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,7 +1,7 @@
 class CommunitiesController < ApplicationController
   include CommunitiesHelper
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
   # before_action :past_30days_after_signIn?, only: [:new, :create]
   before_action :get_community_tags, only: [:index, :search, :tag_search]
   before_action :get_available_tags, only: [:new, :edit]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :only_login_user!
   before_action :get_unchecked_announce_count,
                 :get_not_done_reviews_count,
-                :get_current_level, only: :index
+                only: :index
   impressionist :actions => [:show]
 
   def index

--- a/app/controllers/mistakes_controller.rb
+++ b/app/controllers/mistakes_controller.rb
@@ -1,6 +1,6 @@
 class MistakesController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level, except: :destroy
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, except: :destroy
 
   def index
     @category = QuizCategory.find(params[:id])

--- a/app/controllers/quiz_categories_controller.rb
+++ b/app/controllers/quiz_categories_controller.rb
@@ -1,10 +1,9 @@
 class QuizCategoriesController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
 
   def index
     @levels = QuizCategory.levels
-    get_user_level(current_user)
   end
 
   def show

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,7 +1,7 @@
 class QuizzesController < ApplicationController
   include QuizzesHelper
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
 
   def play
     @category = QuizCategory.find(params[:id])

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,6 @@
 class ReviewsController < ApplicationController
   before_action :only_login_user!
-  before_action :get_current_level, :get_unchecked_announce_count, :get_not_done_reviews_count
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
 
   def index
     reviews = current_user.reviews.includes(:quiz_category)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,5 @@
 class StaticPagesController < ApplicationController
   before_action :admin_root
-  before_action :get_current_level
 
   def home
     if user_signed_in?

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,6 +1,6 @@
 class TalksController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
   before_action :set_ranked_talks, only: [:feed]
   before_action :from_feed?, only: [:new, :edit, :create, :edit]
   before_action :get_community_id, only: [:new, :edit, :create]

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,7 +4,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
   before_action :only_login_user!, only: [:edit, :update, :destory]
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level, only: :edit
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, only: :edit
 
   def create
     build_resource(sign_up_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,19 +1,14 @@
 class UsersController < ApplicationController
   before_action :only_login_user!
-  before_action :get_unchecked_announce_count, :get_not_done_reviews_count, :get_current_level
+  before_action :get_unchecked_announce_count, :get_not_done_reviews_count
 
   def index
     @users = User.includes(:user_experience)
             .order("user_experiences.total_point desc")
-    get_current_level
   end
 
   def show
-    if @user = User.find_by_id(params[:id])
-      get_user_level(current_user)
-    else
-      redirect_to root_path
-    end
+    @user = User.find_by_id(params[:id])
   end
 
 end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,10 +1,3 @@
 class Level < ApplicationRecord
   validates :threshold, presence: true
-
-  scope :get_current_level, -> {
-    order(threshold: :desc).
-    limit(1).
-    pluck(:id).
-    first
-  }
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -32,16 +32,18 @@
       <%= link_to "全件表示", admin_users_path(anchor: "index"), class: "new_btn" %>
       <span class="scroll_x">※ 横スクロール可</span>
     </p>
-    <table class="index_table">
-      <thead>
-        <%= render 'columns' %>
-      </thead>
-      <tbody>
-        <% if @users.present? %>
-          <%= render partial: 'user', collection: @users, as: :user %>
-        <% end %>
-      </tbody>
-    </table>
+    <div class="table_wrapper">
+      <table class="index_table">
+        <thead>
+          <%= render 'columns' %>
+        </thead>
+        <tbody>
+          <% if @users.present? %>
+            <%= render partial: 'user', collection: @users, as: :user %>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
     <%= paginate @users, :params => { anchor: "index" } %>
     <% if @users.blank? %>
       <div class="no_result">

--- a/app/views/application/_user_menu_in_mobile.html.erb
+++ b/app/views/application/_user_menu_in_mobile.html.erb
@@ -24,36 +24,28 @@
   <% end %>
 </div>
 <div class="user_info center">
-  <h2><%= current_user.name %></h2>
-  <h2>Lv.<%= @current_level %></h2>
+  <p class="user_name"><%= current_user.name %></p>
+  <p class="current_level">Lv.<%= current_user.level %></p>
 </div>
 <div class="user_menu_wrapper">
   <%= link_to user_path(current_user) do %>
     <div class="user_menu_panel orange_bg">
-      <div class="panel_inner_box">
-        <p class="menu_name bold">Profile<br><%= icon("fas fa-fw", "address-card") %></p>
-      </div>
+      <p class="menu_name bold">Profile<br><%= icon("fas fa-fw", "address-card") %></p>
     </div>
   <% end %>
   <%= link_to events_path do %>
     <div class="user_menu_panel blue_bg">
-      <div class="panel_inner_box">
-        <p class="menu_name bold">Calendar<br><%= icon("fas fa-fw", "calendar-alt") %></p>
-      </div>
+      <p class="menu_name bold">Calendar<br><%= icon("fas fa-fw", "calendar-alt") %></p>
     </div>
   <% end %>
   <%= link_to bookmarks_path do %>
     <div class="user_menu_panel yellow_bg">
-      <div class="panel_inner_box">
-        <p class="menu_name bold">Bookmark<br><%= icon("fas fa-fw", "star") %></p>
-      </div>
+      <p class="menu_name bold">Bookmark<br><%= icon("fas fa-fw", "star") %></p>
     </div>
   <% end %>
   <%= link_to destroy_user_session_path, method: :delete do %>
     <div class="user_menu_panel gray_bg">
-      <div class="panel_inner_box">
-        <p class="menu_name bold">Log out<br><%= icon("fas fa-fw", "sign-out-alt") %></p>
-      </div>
+      <p class="menu_name bold">Log out<br><%= icon("fas fa-fw", "sign-out-alt") %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/application/_user_profile.html.erb
+++ b/app/views/application/_user_profile.html.erb
@@ -26,7 +26,7 @@
     </li>
     <li>
       <p>Level</p>
-      <p><%= @current_level || "1" %></p>
+      <p><%= @user.level %></p>
     </li>
     <li>
       <p>Total Experience</p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,7 @@
       <% else %>
         <%= icon("fas", "user") %>
       <% end %>
-      <span><%= current_user.name %> (Lv.<%= @current_level || "1"%>)</span>
+      <span><%= current_user.name %> (Lv.<%= current_user.level %>)</span>
     </li>
     <li class="announce_btn inline">
       <%= link_to announcements_path do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,11 +20,11 @@
     </li>
     <li>
       <p>~ Level ~</p>
-      <p><%= @current_level || "1" %></p>
+      <p><%= @user.level %></p>
     </li>
     <li>
       <p>~ Total Experience ~</p>
-      <p><%= @current_experience.to_s(:delimited) %></p>
+      <p><%= @user.user_experience.total_point.to_s(:delimited) %></p>
     </li>
     <li>
       <p>~ Total Play Count ~</p>

--- a/db/migrate/20200808090913_add_column_level_to_user.rb
+++ b/db/migrate/20200808090913_add_column_level_to_user.rb
@@ -1,0 +1,9 @@
+class AddColumnLevelToUser < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :level, :integer, default: 1
+  end
+
+  def down
+    remove_column :users, :level, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_01_073836) do
+ActiveRecord::Schema.define(version: 2020_08_08_090913) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -340,6 +340,7 @@ ActiveRecord::Schema.define(version: 2020_08_01_073836) do
     t.integer "community_count", default: 0, null: false
     t.integer "talk_count", default: 0, null: false
     t.integer "play_count", default: 0, null: false
+    t.integer "level", default: 1
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true


### PR DESCRIPTION
ISSUE
[#112 ](https://github.com/hidetoshi-tsubaki/japanepa.com/issues/112)

変更内容
・ユーザーカラムに「レベル」を追加
・クイズ回答後の処理にレベルが上がったら、レベルカラムを更新する処理を追加
・ページ内のレベルを表示するための共通処理を削除（application_controller.rb）
・HTMLにあるレベル表示に関する記述を「current_user.level」に変更（ヘッダー、プロフィールページ等）
