### PR TITLE
modify javascript for quiz page

### DIFF
--- a/app/assets/javascripts/quiz.js
+++ b/app/assets/javascripts/quiz.js
@@ -26,13 +26,15 @@
     }
     isAnswered = true;
     if ($(li).text() === quizSet[currentNum].choices[0]) {
-      $('#choice li').addClass('correct_answer');
+      $(li).addClass('correct_answer');
       $('#correct_circle').removeClass('hidden');
       correct_ids.push(quizSet[currentNum].id)
       score++;
     } else {
       $(li).addClass('wrong_answer');
-      $(`li:contains(${quizSet[currentNum].choices[0]})`).addClass('correct_answer');
+      $("li").filter(function(){
+        return $(this).text() === quizSet[currentNum].choices[0];
+      }).addClass('correct_answer');
       $('#wrong_cross').removeClass('hidden');
       mistake_ids.push(quizSet[currentNum].id)
     }


### PR DESCRIPTION
変更内容
間違えた場合に、正解の文字列と完全一致させる形で正解の選択肢を指定させる。

変更理由
cotainで正解の選択肢を指定した場合、
例えば、「si」「i」の選択肢を両方とも正解と判断し、背景を緑に変えてしまうため、
選択肢の文字列をfor分で回し、完全一致させる処理に変更。