### PR TITLE
feature/202008/Modify id selecter in date form

### DIFF
--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -4,11 +4,11 @@
     <%= render "radio_button", f: f %>
     <div class="field">
       <%= f.label :title %>
-      <%= f.text_field :title %>
+      <%= f.text_field :title, id: 'title_input' %>
     </div>
     <div class="field">
       <%= f.label :contents %>
-      <%= f.text_area :contents, class: 'question_input', 'data-provider': :summernote %>
+      <%= f.text_area :contents, id: 'contents_input', 'data-provider': :summernote %>
     </div>
     <div class="actions">
       <%= f.submit form_btn, data: { confirm: "送信しますか？"} %>

--- a/app/views/admin/events/_event_date_form.html.erb
+++ b/app/views/admin/events/_event_date_form.html.erb
@@ -1,6 +1,6 @@
 <p class="bold">Start date</p>
 <div class="form-group date_form">
-  <div class="field input-group date", id="start_time", data-target-input="nearest">
+  <div class="field input-group date", data-target-input="nearest">
     <%= f.text_field :start_time, class: "form-control datetimepicker-input start_time", data: { target: "#start_time" }, placeholder: "from..." %>
     <div class="input-group-append" data-target="#start_time" data-toggle="datetimepicker">
       <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
@@ -9,7 +9,7 @@
 </div>
 <p class="bold">End date</p>
 <div class="form-group date_form">
-  <div class="field input-group date", id="end_time", data-target-input="nearest">
+  <div class="field input-group date", data-target-input="nearest">
     <%= f.text_field :end_time, class: "form-control datetimepicker-input end_time", data: { target: "#end_time" }, placeholder: "to..." %>
     <div class="input-group-append" data-target="#end_time" data-toggle="datetimepicker">
       <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>

--- a/app/views/admin/events/_event_date_search.html.erb
+++ b/app/views/admin/events/_event_date_search.html.erb
@@ -2,17 +2,17 @@
 <p class="bold">開始日</p>
 <div class="date_search">
   <div class="form-group date_form inline">
-    <div class="field input-group date date_form" id="creation_date_from" data-target-input="nearest">
-      <%= f.text_field :start_time_gteq, class: "form-control datetimepicker-input", id: "creation_date_from", data: {toggle: "from_date", target: "#creation_date_from"}, placeholder: "from..." %>
-      <div class="input-group-append" data-target="#creation_date_from" data-toggle="datetimepicker">
+    <div class="field input-group date date_form" data-target-input="nearest">
+      <%= f.text_field :start_time_gteq, class: "form-control datetimepicker-input", id: "start_time_from", data: {toggle: "from_date", target: "#start_time_from"}, placeholder: "from..." %>
+      <div class="input-group-append" data-target="#start_time_from" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
       </div>
     </div>
   </div>
   <div class="form-group date_form inline">
-    <div class="field input-group date date_form" id="creation_date_to" data-target-input="nearest">
-      <%= f.text_field :start_time_lt, class: "form-control datetimepicker-input", id: "creation_date_to", data: {toggle: "to_date", target: "#creation_date_to"}, placeholder: "to..." %>
-      <div class="input-group-append" data-target="#creation_date_to" data-toggle="datetimepicker">
+    <div class="field input-group date date_form" data-target-input="nearest">
+      <%= f.text_field :start_time_lt, class: "form-control datetimepicker-input", id: "start_time_to", data: {toggle: "to_date", target: "#start_time_to"}, placeholder: "to..." %>
+      <div class="input-group-append" data-target="#start_time_to" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
       </div>
     </div>
@@ -21,17 +21,17 @@
 <p class="bold">終了日</p>
 <div class="date_search">
   <div class="form-group date_form inline">
-    <div class="input-group date date_form" id="update_date_from" data-target-input="nearest">
-      <%= f.text_field :end_time_gteq, class: "form-control datetimepicker-input", id: "update_date_from", data: {toggle: "from_date", target: "#update_date_from"}, placeholder: "from..." %>
-      <div class="input-group-append" data-target="#update_date_from" data-toggle="datetimepicker">
+    <div class="input-group date date_form" data-target-input="nearest">
+      <%= f.text_field :end_time_gteq, class: "form-control datetimepicker-input", id: "end_time_from", data: {toggle: "from_date", target: "#end_time_from"}, placeholder: "from..." %>
+      <div class="input-group-append" data-target="#end_time_from" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
       </div>
     </div>
   </div>
   <div class="form-group date_form inline">
-    <div class="input-group date date_form" id="update_date_to" data-target-input="nearest">
-      <%= f.text_field :end_time_lt, class: "form-control datetimepicker-input", id: "update_date_to", data: {toggle: "to_date", target: "#update_date_to"}, placeholder: "to..." %>
-      <div class="input-group-append" data-target="#update_date_to" data-toggle="datetimepicker">
+    <div class="input-group date date_form" data-target-input="nearest">
+      <%= f.text_field :end_time_lt, class: "form-control datetimepicker-input", id: "end_time_to", data: {toggle: "to_date", target: "#end_time_to"}, placeholder: "to..." %>
+      <div class="input-group-append" data-target="#end_time_to" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
       </div>
     </div>

--- a/app/views/application/_creation_date_search.html.erb
+++ b/app/views/application/_creation_date_search.html.erb
@@ -1,7 +1,7 @@
 <p class="bold">作成日</p>
 <div class="date_search">
   <div class="form-group date_form inline">
-    <div class="field input-group date date_form" id="creation_date_from" data-target-input="nearest">
+    <div class="field input-group date date_form"  data-target-input="nearest">
       <%= f.text_field :created_at_gteq, class: "form-control datetimepicker-input", id: "creation_date_from", data: {toggle: "from_date", target: "#creation_date_from"}, placeholder: "from..." %>
       <div class="input-group-append" data-target="#creation_date_from" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
@@ -9,7 +9,7 @@
     </div>
   </div>
   <div class="form-group date_form inline">
-    <div class="field input-group date date_form" id="creation_date_to" data-target-input="nearest">
+    <div class="field input-group date date_form"  data-target-input="nearest">
       <%= f.text_field :created_at_lt, class: "form-control datetimepicker-input", id: "creation_date_to", data: {toggle: "to_date", target: "#creation_date_to"}, placeholder: "to..." %>
       <div class="input-group-append" data-target="#creation_date_to" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>

--- a/app/views/application/_update_date_search.html.erb
+++ b/app/views/application/_update_date_search.html.erb
@@ -1,16 +1,16 @@
 <p class="bold">更新日</p>
 <div class="date_search">
   <div class="form-group date_form inline">
-    <div class="field input-group date", id="update_date_from", data-target-input="nearest">
-      <%= f.text_field :updated_at_gteq, class: "form-control datetimepicker-input update_date_from", data: { toggle: "from_date", target: "#update_date_from" }, placeholder: "from..." %>
+    <div class="field input-group date", data-target-input="nearest">
+      <%= f.text_field :updated_at_gteq, class: "form-control datetimepicker-input", id:"update_date_from", data: { toggle: "from_date", target: "#update_date_from" }, placeholder: "from..." %>
       <div class="input-group-append" data-target="#update_date_from" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
       </div>
     </div>
   </div>
   <div class="form-group date_form inline">
-    <div class="field input-group date", id="update_date_to", data-target-input="nearest">
-      <%= f.text_field :updated_at_lteq, class: "form-control datetimepicker-input update_date_to", data: { toggle: "from_date", target: "#update_date_to" }, placeholder: "to..." %>
+    <div class="field input-group date", data-target-input="nearest">
+      <%= f.text_field :updated_at_lteq, class: "form-control datetimepicker-input", id: "update_date_to", data: { toggle: "from_date", target: "#update_date_to" }, placeholder: "to..." %>
       <div class="input-group-append" data-target="#update_date_to" data-toggle="datetimepicker">
         <div class="input-group-text"><i class="fa fa-calendar-alt"></i></div>
       </div>


### PR DESCRIPTION
変更内容
レベルの経験値テーブルを作成するための計算を変更

変更理由
レベル間の経験値の差が狭すぎるため、一回のクイズ回答で得られる経験値で、レベルが飛び級で上がってしまう。