### PR TITLE
feature/202009/Add show page to announcement

### DIFF
--- a/app/views/announcements/_announce.html.erb
+++ b/app/views/announcements/_announce.html.erb
@@ -1,9 +1,11 @@
-<tr class="announce" id=<%= announce.id %>>
-  <td class="center"><%= announce.created_at.strftime('%Y.%m.%d') %></td>
-  <td class="center" id="checked_status_<%= announce.id %>">
-    <% unless current_user.aleady_checked?(announce) %>
-      <span class="label_new bold"> NEW </span>
-    <% end %>
-  </td>
-  <td><%= announce.title %></td>
-</tr>
+<div class="announce_<%= announce.id %>">
+  <%= link_to announcement_path(announce) do %>
+    <p class="center"><%= announce.created_at.strftime('%Y.%m.%d') %></p>
+    <p class="center" id="checked_status_<%= announce.id %>">
+      <% unless current_user.aleady_checked?(announce) %>
+        <span class="label_new bold"> NEW </span>
+      <% end %>
+    </p>
+    <p><%= announce.title %></p>
+  <% end %>
+</div>

--- a/app/views/announcements/_announce_detail.html.erb
+++ b/app/views/announcements/_announce_detail.html.erb
@@ -1,6 +1,5 @@
 <div class="announce_detail_wrapper">
-  <p class="announce_name center bold"><%= announce.title %></p>
-  <p class="announce_date right">
+  <p class="announce_date">
     <span class="posted_day">
       <% if updated?(announce) %>
         <%= icon("fas", "sync-alt") %> <%= announce.updated_at.strftime('%Y/%m/%d') %>
@@ -9,6 +8,7 @@
       <% end %>
     </span>
   </p>
+  <p class="announce_name center bold"><%= announce.title %></p>
   <hr>
   <div class="announce_detail">
     <%= raw(announce.contents) %>

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:html_title) { 'Announcement Detail' } %>
+<% breadcrumb :show_announcement, @announce %>
+<div class="announce_detail_wrapper">
+  <p class="announce_date">
+    <span class="posted_day">
+      <% if updated?(@announce) %>
+        <%= icon("fas", "sync-alt") %> <%= @announce.updated_at.strftime('%Y/%m/%d') %>
+      <% else %>
+        <%= icon("fas", "clock") %> <%= @announce.created_at.strftime('%Y/%m/%d') %>
+      <% end %>
+    </span>
+  </p>
+  <p class="announce_name center bold"><%= @announce.title %></p>
+  <hr>
+  <div class="announce_detail">
+    <%= raw(@announce.contents) %>
+  </div>
+</div>


### PR DESCRIPTION
変更内容
announcementの詳細ページの表示にajaxを使うのをやめ、新たに詳細ページのhtmlを作成。

変更理由
1. ajaxを使うと、rspecのテストに落ちやすくなる
2.特にajaxを使う必要もないため